### PR TITLE
AI Chat MVP (regex draft + confirm flow)

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -52,3 +52,11 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $route['default_controller'] = 'dashboard';
 $route['404_override'] = '';
 $route['translate_uri_dashes'] = FALSE;
+
+// AI Chat
+$route['chat'] = 'chat/index';
+$route['chat/thread/(:num)'] = 'chat/thread/$1';
+$route['chat/new_thread'] = 'chat/new_thread';
+$route['chat/clear_history'] = 'chat/clear_history';
+$route['chat/send/(:num)'] = 'chat/send/$1';
+$route['chat/confirm/(:num)'] = 'chat/confirm/$1';

--- a/application/controllers/Chat.php
+++ b/application/controllers/Chat.php
@@ -1,0 +1,173 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Chat extends CI_Controller
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->model('Chat_model');
+        $this->load->model('Transaction_model');
+        $this->load->model('User_model');
+        $this->load->library('form_validation');
+        $this->load->library('TransactionExtractor');
+
+        if (!$this->session->userdata('user_id')) {
+            redirect('auth/login');
+        }
+    }
+
+    public function index()
+    {
+        $user_id = $this->session->userdata('user_id');
+
+        $thread_id = $this->input->get('thread');
+        if ($thread_id) {
+            redirect('chat/thread/' . (int)$thread_id);
+        }
+
+        $threads = $this->Chat_model->get_threads($user_id);
+        if (empty($threads)) {
+            $newId = $this->Chat_model->create_thread($user_id, 'New chat');
+            redirect('chat/thread/' . (int)$newId);
+        }
+
+        redirect('chat/thread/' . (int)$threads[0]['id']);
+    }
+
+    public function thread($thread_id)
+    {
+        $user_id = $this->session->userdata('user_id');
+        $thread_id = (int)$thread_id;
+
+        $thread = $this->Chat_model->get_thread($thread_id);
+        if (!$thread || (int)$thread['user_id'] !== (int)$user_id) {
+            show_error('Thread not found', 404);
+            return;
+        }
+
+        $data = [];
+        $data['threads'] = $this->Chat_model->get_threads($user_id, 50);
+        $data['thread'] = $thread;
+        $data['messages'] = $this->Chat_model->get_messages($thread_id, 200);
+
+        $this->load->view('templates/header', $data);
+        $this->load->view('chat/index', $data);
+        $this->load->view('templates/main_footer');
+    }
+
+    public function new_thread()
+    {
+        $user_id = $this->session->userdata('user_id');
+        $id = $this->Chat_model->create_thread($user_id, 'New chat');
+        redirect('chat/thread/' . (int)$id);
+    }
+
+    public function clear_history()
+    {
+        $user_id = $this->session->userdata('user_id');
+        $this->Chat_model->delete_threads_for_user($user_id);
+        $id = $this->Chat_model->create_thread($user_id, 'New chat');
+        redirect('chat/thread/' . (int)$id);
+    }
+
+    public function send($thread_id)
+    {
+        if (!$this->input->is_ajax_request()) {
+            show_404();
+            return;
+        }
+
+        $user_id = $this->session->userdata('user_id');
+        $thread_id = (int)$thread_id;
+        $thread = $this->Chat_model->get_thread($thread_id);
+        if (!$thread || (int)$thread['user_id'] !== (int)$user_id) {
+            $this->output->set_status_header(404);
+            echo json_encode(['status' => 'error', 'message' => 'Thread not found']);
+            return;
+        }
+
+        $message = trim((string)$this->input->post('message'));
+        if ($message === '') {
+            echo json_encode(['status' => 'error', 'message' => 'Message is empty']);
+            return;
+        }
+
+        $this->Chat_model->add_message($thread_id, 'user', $message);
+
+        $today = date('Y-m-d');
+        $result = $this->transactionextractor->extract($message, $today);
+
+        if ($result['intent'] === 'create_transaction') {
+            $assistantText = "Aku buat draft transaksi. Cek dulu ya, lalu klik Confirm.";
+        } elseif ($result['intent'] === 'clarify') {
+            $assistantText = $result['questions'][0] ?? 'Bisa jelasin sedikit lagi?';
+        } else {
+            $assistantText = 'Aku belum yakin ini transaksi. Bisa jelaskan lagi?';
+        }
+
+        $this->Chat_model->add_message($thread_id, 'assistant', $assistantText, $result);
+
+        echo json_encode([
+            'status' => 'success',
+            'assistant' => [
+                'content' => $assistantText,
+                'meta' => $result,
+            ],
+        ]);
+    }
+
+    public function confirm($thread_id)
+    {
+        if (!$this->input->is_ajax_request()) {
+            show_404();
+            return;
+        }
+
+        $user_id = $this->session->userdata('user_id');
+        $thread_id = (int)$thread_id;
+        $thread = $this->Chat_model->get_thread($thread_id);
+        if (!$thread || (int)$thread['user_id'] !== (int)$user_id) {
+            $this->output->set_status_header(404);
+            echo json_encode(['status' => 'error', 'message' => 'Thread not found']);
+            return;
+        }
+
+        // Validate draft payload similar to Dashboard::add
+        $this->form_validation->set_rules('type', 'Type', 'required|in_list[income,expense]');
+        $this->form_validation->set_rules('title', 'Title', 'required|trim');
+        $this->form_validation->set_rules('amount', 'Amount', 'required|numeric');
+        $this->form_validation->set_rules('category', 'Category', 'required|trim');
+        $this->form_validation->set_rules('transaction_date', 'Date', 'required');
+
+        if ($this->form_validation->run() === FALSE) {
+            echo json_encode(['status' => 'error', 'message' => strip_tags(validation_errors())]);
+            return;
+        }
+
+        $type = $this->input->post('type');
+        $title = $this->input->post('title');
+        $amount = $this->input->post('amount');
+        $category = $this->input->post('category');
+        $payee = $this->input->post('payee');
+        $date = $this->input->post('transaction_date');
+
+        $final_category = $this->Transaction_model->get_or_create_category($category, $type, $user_id);
+
+        $data = [
+            'user_id' => $user_id,
+            'title' => $title,
+            'amount' => $amount,
+            'type' => $type,
+            'category' => $final_category,
+            'payee' => $payee,
+            'transaction_date' => $date,
+        ];
+        $this->Transaction_model->add_transaction($data);
+
+        $this->Chat_model->add_message($thread_id, 'assistant', 'Sip, transaksinya sudah disimpan.');
+
+        echo json_encode(['status' => 'success', 'message' => 'Transaction saved']);
+    }
+}
+

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -145,6 +145,16 @@ class Dashboard extends CI_Controller
             // Using get_categories_by_user to support both global and user specific
             $data['categories'] = $this->Transaction_model->get_categories_by_user(null, $user_id);
 
+            // Optional prefill from query params (used by AI Chat "Edit" flow).
+            $data['prefill'] = [
+                'type' => $this->input->get('type'),
+                'title' => $this->input->get('title'),
+                'amount' => $this->input->get('amount'),
+                'category' => $this->input->get('category'),
+                'payee' => $this->input->get('payee'),
+                'date' => $this->input->get('date'),
+            ];
+
             $this->load->view('templates/header', $data);
             $this->load->view('dashboard/add', $data);
             $this->load->view('templates/main_footer');

--- a/application/libraries/TransactionExtractor.php
+++ b/application/libraries/TransactionExtractor.php
@@ -1,0 +1,161 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Cheap-first transaction extractor.
+ *
+ * This intentionally starts with deterministic parsing (regex) to reduce LLM cost.
+ * If not confident, caller can fall back to an LLM provider (not implemented here).
+ */
+class TransactionExtractor
+{
+    public function extract($text, $todayYmd)
+    {
+        $text = trim((string)$text);
+        if ($text === '') {
+            return $this->clarify(['message'], 'Pesannya kosong. Mau catat transaksi apa?');
+        }
+
+        $lower = mb_strtolower($text, 'UTF-8');
+
+        $type = $this->guess_type($lower);
+        $amount = $this->parse_amount_idr($lower);
+        $date = $this->parse_date($lower, $todayYmd);
+
+        $missing = [];
+        if (!$type) $missing[] = 'type';
+        if ($amount === null) $missing[] = 'amount';
+        if (!$date) $missing[] = 'transaction_date';
+
+        if (!empty($missing)) {
+            // Ask 1 most important question to proceed.
+            if (in_array('amount', $missing, true)) {
+                return $this->clarify($missing, 'Berapa jumlahnya (contoh: 25k, 35 ribu, 2jt)?');
+            }
+            if (in_array('type', $missing, true)) {
+                return $this->clarify($missing, 'Ini pemasukan atau pengeluaran?');
+            }
+            return $this->clarify($missing, 'Tanggal berapa transaksinya? (contoh: hari ini / kemarin / 2026-04-27)');
+        }
+
+        // Title heuristic: remove amount and some keywords; keep it short.
+        $title = $this->guess_title($lower);
+
+        return [
+            'intent' => 'create_transaction',
+            'draft' => [
+                'type' => $type,
+                'amount' => $amount,
+                'transaction_date' => $date,
+                'category' => 'Uncategorized',
+                'title' => $title ?: $text,
+                'payee' => '',
+            ],
+            'missing' => [],
+            'questions' => [],
+            'confidence' => 0.65,
+        ];
+    }
+
+    private function clarify($missing, $question)
+    {
+        return [
+            'intent' => 'clarify',
+            'draft' => null,
+            'missing' => array_values($missing),
+            'questions' => [$question],
+            'confidence' => 0.0,
+        ];
+    }
+
+    private function guess_type($lower)
+    {
+        // Very simple heuristics for Indonesian.
+        $incomeWords = ['gaji', 'salary', 'masuk', 'income', 'pendapatan', 'bonus', 'refund', 'dibayar', 'terima'];
+        $expenseWords = ['beli', 'bayar', 'jajan', 'makan', 'ngopi', 'expense', 'keluar', 'tagihan', 'top up', 'topup'];
+
+        foreach ($incomeWords as $w) {
+            if (strpos($lower, $w) !== false) return 'income';
+        }
+        foreach ($expenseWords as $w) {
+            if (strpos($lower, $w) !== false) return 'expense';
+        }
+        return null;
+    }
+
+    /**
+     * Parses Indonesian amount formats into integer IDR.
+     * Supports: 35 ribu, 250k, 7.5jt, 7.500.000, 7500000
+     */
+    private function parse_amount_idr($lower)
+    {
+        // 7.500.000 or 7,500,000
+        if (preg_match('/\\b(\\d{1,3}([\\.,]\\d{3})+)(?!\\d)\\b/u', $lower, $m)) {
+            $n = preg_replace('/[\\.,]/', '', $m[1]);
+            return is_numeric($n) ? (int)$n : null;
+        }
+
+        // 250k, 10k
+        if (preg_match('/\\b(\\d+(?:[\\.,]\\d+)?)\\s*k\\b/u', $lower, $m)) {
+            return (int)round(((float)str_replace(',', '.', $m[1])) * 1000);
+        }
+
+        // 7.5jt, 2jt
+        if (preg_match('/\\b(\\d+(?:[\\.,]\\d+)?)\\s*(jt|juta)\\b/u', $lower, $m)) {
+            return (int)round(((float)str_replace(',', '.', $m[1])) * 1000000);
+        }
+
+        // 35 ribu
+        if (preg_match('/\\b(\\d+(?:[\\.,]\\d+)?)\\s*(rb|ribu)\\b/u', $lower, $m)) {
+            return (int)round(((float)str_replace(',', '.', $m[1])) * 1000);
+        }
+
+        // Plain number (avoid matching dates like 2026-04-27 by requiring >= 3 digits)
+        if (preg_match('/\\b(\\d{3,})\\b/u', $lower, $m)) {
+            return (int)$m[1];
+        }
+
+        return null;
+    }
+
+    private function parse_date($lower, $todayYmd)
+    {
+        // ISO date
+        if (preg_match('/\\b(\\d{4}-\\d{2}-\\d{2})\\b/u', $lower, $m)) {
+            return $m[1];
+        }
+
+        // Relative
+        if (strpos($lower, 'hari ini') !== false || strpos($lower, 'today') !== false) {
+            return $todayYmd;
+        }
+        if (strpos($lower, 'kemarin') !== false || strpos($lower, 'yesterday') !== false) {
+            return date('Y-m-d', strtotime($todayYmd . ' -1 day'));
+        }
+
+        // "tgl 25" or "tanggal 25"
+        if (preg_match('/\\b(tgl|tanggal)\\s*(\\d{1,2})\\b/u', $lower, $m)) {
+            $day = (int)$m[2];
+            $year = (int)date('Y', strtotime($todayYmd));
+            $month = (int)date('m', strtotime($todayYmd));
+            if ($day >= 1 && $day <= 31) {
+                $candidate = sprintf('%04d-%02d-%02d', $year, $month, $day);
+                return $candidate;
+            }
+        }
+
+        return $todayYmd; // Default to today for MVP
+    }
+
+    private function guess_title($lower)
+    {
+        // Remove common prefixes and amount tokens; keep first ~40 chars.
+        $t = preg_replace('/\\b(beli|bayar|gaji|masuk|keluar|transfer|top\\s*up|topup)\\b/u', '', $lower);
+        $t = preg_replace('/\\b\\d+(?:[\\.,]\\d+)?\\s*(k|jt|juta|rb|ribu)\\b/u', '', $t);
+        $t = preg_replace('/\\b\\d{1,3}([\\.,]\\d{3})+\\b/u', '', $t);
+        $t = trim(preg_replace('/\\s+/', ' ', $t));
+        if ($t === '') return '';
+        return mb_substr($t, 0, 40, 'UTF-8');
+    }
+}
+

--- a/application/models/Chat_model.php
+++ b/application/models/Chat_model.php
@@ -1,0 +1,72 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Chat_model extends CI_Model
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->database();
+    }
+
+    public function create_thread($user_id, $title = null)
+    {
+        $data = [
+            'user_id' => $user_id,
+            'title' => $title,
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ];
+        $this->db->insert('chat_threads', $data);
+        return $this->db->insert_id();
+    }
+
+    public function get_threads($user_id, $limit = 20)
+    {
+        $this->db->where('user_id', $user_id);
+        $this->db->order_by('updated_at', 'DESC');
+        $this->db->limit($limit);
+        return $this->db->get('chat_threads')->result_array();
+    }
+
+    public function get_thread($thread_id)
+    {
+        return $this->db->get_where('chat_threads', ['id' => $thread_id])->row_array();
+    }
+
+    public function touch_thread($thread_id)
+    {
+        $this->db->where('id', $thread_id);
+        return $this->db->update('chat_threads', ['updated_at' => date('Y-m-d H:i:s')]);
+    }
+
+    public function add_message($thread_id, $role, $content, $meta = null)
+    {
+        $data = [
+            'thread_id' => $thread_id,
+            'role' => $role,
+            'content' => $content,
+            'meta_json' => $meta ? json_encode($meta) : null,
+            'created_at' => date('Y-m-d H:i:s'),
+        ];
+        $this->db->insert('chat_messages', $data);
+        $this->touch_thread($thread_id);
+        return $this->db->insert_id();
+    }
+
+    public function get_messages($thread_id, $limit = 100)
+    {
+        $this->db->where('thread_id', $thread_id);
+        $this->db->order_by('id', 'ASC');
+        $this->db->limit($limit);
+        return $this->db->get('chat_messages')->result_array();
+    }
+
+    public function delete_threads_for_user($user_id)
+    {
+        // Foreign keys should cascade from chat_threads -> chat_messages.
+        $this->db->where('user_id', $user_id);
+        return $this->db->delete('chat_threads');
+    }
+}
+

--- a/application/views/chat/index.php
+++ b/application/views/chat/index.php
@@ -1,0 +1,183 @@
+<div class="animate-up">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h4 class="font-mono fw-bold m-0">AI CHAT</h4>
+        <div class="d-flex gap-2">
+            <a href="<?= base_url('chat/new_thread') ?>" class="btn btn-sm border-brutal bg-white font-mono fw-bold">NEW</a>
+            <a href="<?= base_url('chat/clear_history') ?>" class="btn btn-sm border-brutal bg-white font-mono fw-bold"
+                onclick="return confirm('Clear all chat history?')">CLEAR</a>
+        </div>
+    </div>
+
+    <div class="row g-3">
+        <div class="col-12 col-lg-4">
+            <div class="card card-brutal p-3">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                    <span class="font-mono fw-bold">THREADS</span>
+                </div>
+                <div class="list-group list-group-flush">
+                    <?php foreach ($threads as $t): ?>
+                        <a class="list-group-item list-group-item-action border-0 border-top py-2 <?= ((int)$t['id'] === (int)$thread['id']) ? 'active' : '' ?>"
+                            href="<?= base_url('chat/thread/' . $t['id']) ?>">
+                            <div class="d-flex justify-content-between">
+                                <span class="font-mono fw-bold small">
+                                    <?= htmlspecialchars($t['title'] ?: ('Thread #' . $t['id'])) ?>
+                                </span>
+                                <span class="font-mono small text-muted">
+                                    <?= date('m/d H:i', strtotime($t['updated_at'])) ?>
+                                </span>
+                            </div>
+                        </a>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12 col-lg-8">
+            <div class="card card-brutal p-3">
+                <div id="chatMessages" style="max-height: 55vh; overflow:auto;">
+                    <?php foreach ($messages as $m): ?>
+                        <?php
+                        $isUser = ($m['role'] === 'user');
+                        $meta = null;
+                        if (!empty($m['meta_json'])) {
+                            $meta = json_decode($m['meta_json'], true);
+                        }
+                        ?>
+                        <div class="mb-3 d-flex <?= $isUser ? 'justify-content-end' : 'justify-content-start' ?>">
+                            <div class="p-3 border-brutal <?= $isUser ? 'bg-pastel-blue text-black' : 'bg-white' ?>"
+                                style="max-width: 85%;">
+                                <div class="font-mono small fw-bold mb-1"><?= $isUser ? 'YOU' : 'ASSISTANT' ?></div>
+                                <div class="font-mono" style="white-space: pre-wrap;"><?= htmlspecialchars($m['content']) ?></div>
+
+                                <?php if (!$isUser && is_array($meta) && ($meta['intent'] ?? '') === 'create_transaction' && !empty($meta['draft'])): ?>
+                                    <?php $d = $meta['draft']; ?>
+                                    <div class="mt-3 p-3 border-brutal bg-pastel-yellow">
+                                        <div class="font-mono fw-bold mb-2">DRAFT</div>
+                                        <div class="font-mono small">Type: <b><?= htmlspecialchars($d['type']) ?></b></div>
+                                        <div class="font-mono small">Amount: <b>Rp <?= number_format((int)$d['amount'], 0, ',', '.') ?></b></div>
+                                        <div class="font-mono small">Date: <b><?= htmlspecialchars($d['transaction_date']) ?></b></div>
+                                        <div class="font-mono small">Category: <b><?= htmlspecialchars($d['category']) ?></b></div>
+                                        <div class="font-mono small">Title: <b><?= htmlspecialchars($d['title']) ?></b></div>
+                                        <div class="font-mono small">Payee: <b><?= htmlspecialchars($d['payee']) ?></b></div>
+
+                                        <div class="d-flex gap-2 mt-3">
+                                            <button class="btn btn-sm btn-brutal bg-white font-mono fw-bold"
+                                                onclick="confirmDraft(<?= (int)$thread['id'] ?>, <?= htmlspecialchars(json_encode($d), ENT_QUOTES, 'UTF-8') ?>)">
+                                                CONFIRM
+                                            </button>
+                                            <a class="btn btn-sm border-brutal bg-white font-mono fw-bold"
+                                                href="<?= base_url('dashboard/add') ?>?type=<?= urlencode($d['type']) ?>&title=<?= urlencode($d['title']) ?>&amount=<?= urlencode((string)$d['amount']) ?>&category=<?= urlencode($d['category']) ?>&payee=<?= urlencode($d['payee']) ?>&date=<?= urlencode($d['transaction_date']) ?>">
+                                                EDIT
+                                            </a>
+                                        </div>
+                                    </div>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+
+                <hr class="my-3">
+
+                <form id="chatForm" class="d-flex gap-2">
+                    <input type="text" id="chatInput" class="form-control form-control-brutal font-mono"
+                        placeholder="Ketik transaksi... (contoh: beli kopi 25k kemarin)" autocomplete="off">
+                    <button type="submit" class="btn btn-brutal bg-pastel-green font-mono fw-bold">SEND</button>
+                </form>
+
+                <div id="chatError" class="mt-3 d-none"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    function initPageScripts() {
+        const threadId = <?= (int)$thread['id'] ?>;
+        const $messages = $('#chatMessages');
+        const $form = $('#chatForm');
+        const $input = $('#chatInput');
+        const $error = $('#chatError');
+
+        function scrollBottom() {
+            $messages.scrollTop($messages[0].scrollHeight);
+        }
+
+        scrollBottom();
+
+        function showError(msg) {
+            $error.removeClass('d-none').html(
+                '<div class="alert alert-danger border-brutal mb-0">' + msg + '</div>'
+            );
+        }
+
+        function clearError() {
+            $error.addClass('d-none').html('');
+        }
+
+        $form.on('submit', function (e) {
+            e.preventDefault();
+            clearError();
+            const text = ($input.val() || '').trim();
+            if (!text) return;
+
+            $input.prop('disabled', true);
+            $form.find('button[type="submit"]').prop('disabled', true);
+
+            $.ajax({
+                url: "<?= base_url('chat/send/' . (int)$thread['id']) ?>",
+                method: "POST",
+                dataType: "json",
+                data: { message: text },
+                success: function (res) {
+                    if (res.status !== 'success') {
+                        showError(res.message || 'Failed');
+                        return;
+                    }
+                    // Simpler: reload thread page to render server-side meta/draft.
+                    window.location.reload();
+                },
+                error: function (xhr) {
+                    showError(xhr.responseText || 'Error');
+                },
+                complete: function () {
+                    $input.prop('disabled', false).val('').focus();
+                    $form.find('button[type="submit"]').prop('disabled', false);
+                }
+            });
+        });
+
+        window.confirmDraft = function (threadId, draft) {
+            clearError();
+            document.getElementById('loader-overlay')?.classList.add('active');
+
+            $.ajax({
+                url: "<?= base_url('chat/confirm/' . (int)$thread['id']) ?>",
+                method: "POST",
+                dataType: "json",
+                data: {
+                    type: draft.type,
+                    title: draft.title,
+                    amount: draft.amount,
+                    category: draft.category,
+                    payee: draft.payee,
+                    transaction_date: draft.transaction_date
+                },
+                success: function (res) {
+                    if (res.status !== 'success') {
+                        showError(res.message || 'Failed');
+                        return;
+                    }
+                    window.location.reload();
+                },
+                error: function (xhr) {
+                    showError(xhr.responseText || 'Error');
+                },
+                complete: function () {
+                    document.getElementById('loader-overlay')?.classList.remove('active');
+                }
+            });
+        }
+    }
+</script>
+

--- a/application/views/dashboard/add.php
+++ b/application/views/dashboard/add.php
@@ -1,4 +1,17 @@
 <div class="animate-up">
+    <?php
+    $prefill = isset($prefill) && is_array($prefill) ? $prefill : [];
+    $pfType = $prefill['type'] ?? null;
+    $pfTitle = $prefill['title'] ?? '';
+    $pfAmountRaw = $prefill['amount'] ?? '';
+    $pfAmount = '';
+    if ($pfAmountRaw !== '' && is_numeric($pfAmountRaw)) {
+        $pfAmount = number_format((float)$pfAmountRaw, 0, ',', '.');
+    }
+    $pfCategory = $prefill['category'] ?? '';
+    $pfPayee = $prefill['payee'] ?? '';
+    $pfDate = $prefill['date'] ?? '';
+    ?>
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h4 class="font-mono fw-bold m-0">ADD TRANSACTION</h4>
         <a href="<?= base_url('dashboard/transactions') ?>"
@@ -31,14 +44,14 @@
                 <div class="d-flex gap-3">
                     <div class="form-check flex-fill">
                         <input class="form-check-input border-2 border-black" type="radio" name="type" id="type1"
-                            value="income" checked>
+                            value="income" <?= ($pfType === 'income' || !$pfType) ? 'checked' : '' ?>>
                         <label class="form-check-label font-mono fw-bold" for="type1">
                             INCOME
                         </label>
                     </div>
                     <div class="form-check flex-fill">
                         <input class="form-check-input border-2 border-black" type="radio" name="type" id="type2"
-                            value="expense">
+                            value="expense" <?= ($pfType === 'expense') ? 'checked' : '' ?>>
                         <label class="form-check-label font-mono fw-bold" for="type2">
                             EXPENSE
                         </label>
@@ -49,7 +62,7 @@
             <div class="mb-3">
                 <label class="form-label font-mono fw-bold">TITLE</label>
                 <input type="text" name="title" class="form-control form-control-brutal"
-                    placeholder="e.g. Salary, Coffee" required>
+                    placeholder="e.g. Salary, Coffee" value="<?= htmlspecialchars($pfTitle) ?>" required>
             </div>
 
             <div class="mb-3">
@@ -57,14 +70,14 @@
                 <div class="input-group">
                     <span class="input-group-text border-brutal bg-white fw-bold">Rp</span>
                     <input type="text" name="amount" class="form-control form-control-brutal" placeholder="0"
-                        inputmode="numeric" required>
+                        inputmode="numeric" value="<?= htmlspecialchars($pfAmount) ?>" required>
                 </div>
             </div>
 
             <div class="mb-3">
                 <label class="form-label font-mono fw-bold">CATEGORY</label>
                 <div id="category-select-wrapper">
-                    <select id="categorySelect" name="category" class="form-select form-control-brutal" required>
+                    <select id="categorySelect" name="category" class="form-select form-control-brutal" required data-prefill="<?= htmlspecialchars($pfCategory) ?>">
                         <option value="">-- Select Category --</option>
                         <!-- Dynamic options -->
                         <option value="NEW_CATEGORY">+ ADD NEW CATEGORY...</option>
@@ -85,14 +98,15 @@
             <div class="mb-3">
                 <label class="form-label font-mono fw-bold">PAYEE / RECEIVER</label>
                 <input type="text" name="payee" class="form-control form-control-brutal"
-                    placeholder="e.g. Starbucks, John Doe">
+                    placeholder="e.g. Starbucks, John Doe" value="<?= htmlspecialchars($pfPayee) ?>">
             </div>
 
             <!-- Description removed as per user request -->
 
             <div class="mb-4">
                 <label class="form-label font-mono fw-bold">DATE</label>
-                <input type="date" name="date" class="form-control form-control-brutal" value="<?= date('Y-m-d') ?>"
+                <input type="date" name="date" class="form-control form-control-brutal"
+                    value="<?= htmlspecialchars($pfDate ?: date('Y-m-d')) ?>"
                     required>
             </div>
 
@@ -128,6 +142,7 @@
         function updateCategoryList() {
             const selectedType = $('input[name="type"]:checked').val();
             const currentVal = $categorySelect.val();
+            const prefillVal = $categorySelect.data('prefill');
 
             // Keep "NEW_CATEGORY" option, "Select Category" option, and add filtered ones
             $categorySelect.html('<option value="">-- Select Category --</option>');
@@ -142,6 +157,10 @@
             // Re-select if still valid
             if (currentVal && currentVal !== 'NEW_CATEGORY') {
                 $categorySelect.val(currentVal);
+            }
+            // Initial prefill (only if nothing selected yet)
+            if (!currentVal && prefillVal) {
+                $categorySelect.val(prefillVal);
             }
         }
 

--- a/application/views/templates/main_footer.php
+++ b/application/views/templates/main_footer.php
@@ -14,6 +14,12 @@
         <span>LIST</span>
     </a>
 
+    <a href="<?= base_url('chat') ?>"
+        class="nav-item-brutal <?= ($this->uri->segment(1) == 'chat') ? 'active' : '' ?>">
+        <span class="iconify" data-icon="lucide:message-square"></span>
+        <span>CHAT</span>
+    </a>
+
     <!-- PLUS BUTTON -->
     <a href="<?= base_url('dashboard/add') ?>" class="nav-item-brutal nav-plus">
         <div class="plus-btn">

--- a/finance_app.sql
+++ b/finance_app.sql
@@ -47,3 +47,27 @@ INSERT INTO `categories` (`name`, `type`) VALUES
 ('Shopping', 'expense'),
 ('Utilities', 'expense'),
 ('Others', 'expense');
+
+-- AI Chat tables (threads + messages)
+CREATE TABLE `chat_threads` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`id`),
+  KEY `user_id` (`user_id`),
+  CONSTRAINT `chat_threads_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `chat_messages` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `thread_id` int(11) NOT NULL,
+  `role` enum('user','assistant','system') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `content` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `meta_json` longtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`),
+  KEY `thread_id` (`thread_id`),
+  CONSTRAINT `chat_messages_ibfk_1` FOREIGN KEY (`thread_id`) REFERENCES `chat_threads` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
Implements the first slice of #11 (Epic: AI Chat).\n\nIncluded:\n- New Chat page with threads + message history (DB tables added to finance_app.sql)\n- Cheap-first transaction draft extraction (regex) with clarify question\n- Preview draft card + Confirm flow to create a transaction\n- Edit flow redirects to existing manual add form with prefilled query params\n- Nav entry + routes\n\nNotes:\n- This PR uses regex-only extraction for now; LLM provider integration (Gemini/Groq + failover) comes next.