### PR TITLE
Fix AI env detection in /chat/ai_status

### DIFF
--- a/application/config/ai.php
+++ b/application/config/ai.php
@@ -7,7 +7,10 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 | Keep keys out of git. Prefer injecting via server env vars and reading with getenv().
 */
 
-$config['ai_enabled'] = (bool)(getenv('AI_ENABLED') ?: false);
+// Robust boolean parsing: supports true/false/1/0/yes/no/on/off.
+$aiEnabledRaw = getenv('AI_ENABLED');
+$aiEnabledParsed = filter_var($aiEnabledRaw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+$config['ai_enabled'] = ($aiEnabledParsed === null) ? false : (bool)$aiEnabledParsed;
 
 // Providers: gemini | groq
 $config['ai_provider_primary'] = getenv('AI_PROVIDER_PRIMARY') ?: 'gemini';

--- a/application/controllers/Chat.php
+++ b/application/controllers/Chat.php
@@ -222,6 +222,14 @@ class Chat extends CI_Controller
         if (!is_array($aiCfg)) $aiCfg = [];
 
         $out = [
+            // Diagnostics (do not leak secrets)
+            'dotenv_loaded' => defined('DOTENV_LOADED') ? (bool)DOTENV_LOADED : false,
+            'env_seen' => [
+                'AI_ENABLED_set' => getenv('AI_ENABLED') !== false,
+                'AI_ENABLED_value' => (getenv('AI_ENABLED') !== false) ? (string)getenv('AI_ENABLED') : null,
+                'GEMINI_API_KEY_present' => (string)getenv('GEMINI_API_KEY') !== '',
+                'GROQ_API_KEY_present' => (string)getenv('GROQ_API_KEY') !== '',
+            ],
             'ai_enabled' => (bool)($aiCfg['ai_enabled'] ?? false),
             'primary_provider' => (string)($aiCfg['ai_provider_primary'] ?? ''),
             'fallback_provider' => (string)($aiCfg['ai_provider_fallback'] ?? ''),

--- a/index.php
+++ b/index.php
@@ -102,6 +102,7 @@ if (is_file(__DIR__ . '/vendor/autoload.php') && is_file(__DIR__ . '/.env')) {
     if (class_exists('Dotenv\\Dotenv')) {
         try {
             Dotenv\Dotenv::createImmutable(__DIR__)->safeLoad();
+            define('DOTENV_LOADED', true);
         } catch (Exception $e) {
             // Ignore dotenv load errors; app can still run with system env vars.
         }


### PR DESCRIPTION
Fixes #22.\n\n- Add safe diagnostics to /chat/ai_status (dotenv_loaded + env presence booleans, no secrets)\n- Robust boolean parsing for AI_ENABLED (supports true/false/1/0/etc)\n- Mark DOTENV_LOADED when .env successfully loaded