### PR TITLE
AI Chat: kategori otomatis (AI-first)

### DIFF
--- a/application/controllers/Chat.php
+++ b/application/controllers/Chat.php
@@ -13,6 +13,7 @@ class Chat extends CI_Controller
         $this->load->library('form_validation');
         $this->load->library('TransactionExtractor');
         $this->load->library('TransactionDraftValidator');
+        $this->load->library('CategoryClassifier');
         $this->config->load('ai', true);
 
         if (!$this->session->userdata('user_id')) {
@@ -133,6 +134,23 @@ class Chat extends CI_Controller
                 $llm = $this->extract_with_llm($message, $today, $aiCfg, (int)$user_id);
                 if ($llm) {
                     $result = $llm;
+                }
+            }
+        }
+
+        // Auto category fill (AI-first + strict allowed list + fallback).
+        if (($result['intent'] ?? '') === 'create_transaction' && !empty($result['draft']) && is_array($result['draft'])) {
+            $type = (string)($result['draft']['type'] ?? '');
+            if (in_array($type, ['income', 'expense'], true)) {
+                $allowed = $this->Transaction_model->get_categories_by_user($type, (int)$user_id);
+                $existingCat = trim((string)($result['draft']['category'] ?? ''));
+
+                $allowedNames = array_map(function ($c) { return (string)$c['name']; }, $allowed ?: []);
+                $isAllowed = $existingCat !== '' && in_array($existingCat, $allowedNames, true);
+
+                if (!$isAllowed) {
+                    $cls = $this->categoryclassifier->classify($message, $type, $allowed ?: [], is_array($aiCfg) ? $aiCfg : []);
+                    $result['draft']['category'] = $cls['category'];
                 }
             }
         }
@@ -310,6 +328,11 @@ class Chat extends CI_Controller
         // Build prompt with strict JSON contract. Keep it short for cheaper models.
         $categories = $this->Transaction_model->get_categories_by_user(null, $user_id);
         $catNames = array_map(function ($c) { return $c['name']; }, $categories ?: []);
+        $expenseNames = array_values(array_map(function ($c) { return $c['name']; }, array_filter($categories ?: [], function ($c) { return ($c['type'] ?? '') === 'expense'; })));
+        $incomeNames = array_values(array_map(function ($c) { return $c['name']; }, array_filter($categories ?: [], function ($c) { return ($c['type'] ?? '') === 'income'; })));
+        $defaultExpense = 'Others';
+        foreach ($expenseNames as $n) { if (strcasecmp($n, 'Others') === 0) { $defaultExpense = $n; break; } }
+        $defaultIncome = $incomeNames[0] ?? 'Salary';
 
         $system = "You are a transaction extraction engine. Output JSON only. No markdown.\n"
             . "Contract:\n"
@@ -317,7 +340,7 @@ class Chat extends CI_Controller
             . "Rules:\n"
             . "- Do NOT invent amounts/dates.\n"
             . "- If missing required info, set intent=clarify, include missing fields, ask exactly 1 question.\n"
-            . "- Use category from allowed list when possible; otherwise set category=\"Uncategorized\".\n"
+            . "- category MUST be one of the allowed categories. If unsure: for expense use \"{$defaultExpense}\", for income use \"{$defaultIncome}\".\n"
             . "Today: {$today}\n"
             . "Allowed categories: " . implode(', ', array_slice($catNames, 0, 50));
 

--- a/application/libraries/CategoryClassifier.php
+++ b/application/libraries/CategoryClassifier.php
@@ -1,0 +1,171 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Category classifier for AI Chat transactions.
+ *
+ * AI-first (when enabled) with strict guardrails:
+ * - AI can only choose from allowed categories.
+ * - Otherwise fallback to deterministic keyword rules and then default category.
+ */
+class CategoryClassifier
+{
+    public function classify($text, $type, $allowedCategories, $aiCfg = null)
+    {
+        $text = trim((string)$text);
+        $type = (string)$type;
+        $allowed = $this->normalize_allowed($allowedCategories, $type);
+
+        if (empty($allowed)) {
+            return ['category' => 'Others', 'confidence' => 0.0, 'source' => 'fallback'];
+        }
+
+        $defaultCat = $this->default_category($allowed);
+
+        // AI-first path
+        if (is_array($aiCfg) && !empty($aiCfg['ai_enabled'])) {
+            $ai = $this->classify_with_ai($text, $type, $allowed, $defaultCat, $aiCfg);
+            if ($ai) {
+                return $ai;
+            }
+        }
+
+        // Deterministic rules
+        $rule = $this->classify_with_rules(mb_strtolower($text, 'UTF-8'), $type, $allowed, $defaultCat);
+        if ($rule) {
+            return $rule;
+        }
+
+        return ['category' => $defaultCat, 'confidence' => 0.2, 'source' => 'fallback'];
+    }
+
+    private function normalize_allowed($allowedCategories, $type)
+    {
+        $out = [];
+        if (!is_array($allowedCategories)) return $out;
+        foreach ($allowedCategories as $c) {
+            if (!is_array($c)) continue;
+            if (($c['type'] ?? null) !== $type) continue;
+            $name = trim((string)($c['name'] ?? ''));
+            if ($name === '') continue;
+            $out[] = $name;
+        }
+        return array_values(array_unique($out));
+    }
+
+    private function default_category($allowedNames)
+    {
+        // Prefer "Others" if present, else first allowed category.
+        foreach ($allowedNames as $n) {
+            if (strcasecmp($n, 'Others') === 0) return $n;
+        }
+        return $allowedNames[0] ?? 'Others';
+    }
+
+    private function classify_with_ai($text, $type, $allowedNames, $defaultCat, $aiCfg)
+    {
+        $allowedList = implode(', ', array_slice($allowedNames, 0, 60));
+
+        $system = "Kamu adalah classifier kategori transaksi.\n"
+            . "Balas JSON saja, tanpa markdown.\n"
+            . "Pilih tepat 1 kategori dari daftar ALLOWED.\n"
+            . "Jika tidak yakin, pilih DEFAULT.\n"
+            . "Output format: {\"category\":\"<ALLOWED>\",\"confidence\":0.0}\n"
+            . "TYPE: {$type}\n"
+            . "DEFAULT: {$defaultCat}\n"
+            . "ALLOWED: {$allowedList}";
+
+        $messages = [
+            ['role' => 'system', 'content' => $system],
+            ['role' => 'user', 'content' => $text],
+        ];
+
+        require_once APPPATH . 'libraries/ai/AiRouter.php';
+        $router = new AiRouter($aiCfg);
+        $res = $router->chat($messages);
+        if (empty($res['ok'])) {
+            return null;
+        }
+
+        $payload = $this->parse_json((string)($res['text'] ?? ''));
+        if (!is_array($payload)) return null;
+
+        $cat = trim((string)($payload['category'] ?? ''));
+        $conf = $payload['confidence'] ?? null;
+        if ($cat === '' || !in_array($cat, $allowedNames, true)) {
+            // Strict: only allow exact allowed name.
+            return null;
+        }
+        $confF = is_numeric($conf) ? (float)$conf : 0.5;
+        if ($confF < 0) $confF = 0;
+        if ($confF > 1) $confF = 1;
+
+        return ['category' => $cat, 'confidence' => $confF, 'source' => 'ai'];
+    }
+
+    private function parse_json($text)
+    {
+        $text = trim((string)$text);
+        if ($text === '') return null;
+        $json = json_decode($text, true);
+        if (is_array($json)) return $json;
+        if (preg_match('/\\{[\\s\\S]*\\}/', $text, $m)) {
+            $json = json_decode($m[0], true);
+            if (is_array($json)) return $json;
+        }
+        return null;
+    }
+
+    private function classify_with_rules($lowerText, $type, $allowedNames, $defaultCat)
+    {
+        // Map logical buckets to actual allowed category names.
+        $map = [
+            'food' => ['Food'],
+            'transport' => ['Transport'],
+            'utilities' => ['Utilities'],
+            'health' => ['Health'],
+            'shopping' => ['Shopping'],
+            'entertainment' => ['Entertainment'],
+            'salary' => ['Salary'],
+        ];
+
+        $keywords = [
+            'food' => ['makan', 'nasi', 'ayam', 'kopi', 'minum', 'resto', 'restoran', 'cafe', 'kafe', 'jajan', 'snack'],
+            'transport' => ['bensin', 'bbm', 'gojek', 'grab', 'ojek', 'angkot', 'bus', 'parkir', 'tol', 'taksi', 'kereta'],
+            'utilities' => ['listrik', 'wifi', 'internet', 'pulsa', 'air', 'token', 'pln', 'pd', 'pdam'],
+            'health' => ['obat', 'dokter', 'apotek', 'rumah sakit', 'rs', 'vitamin'],
+            'shopping' => ['belanja', 'tokopedia', 'shopee', 'lazada', 'blibli', 'checkout'],
+            'entertainment' => ['film', 'netflix', 'game', 'spotify', 'hiburan', 'bioskop'],
+            'salary' => ['gaji', 'salary', 'payroll'],
+        ];
+
+        $bucket = null;
+        foreach ($keywords as $b => $words) {
+            foreach ($words as $w) {
+                if (strpos($lowerText, $w) !== false) {
+                    $bucket = $b;
+                    break 2;
+                }
+            }
+        }
+
+        if (!$bucket) return null;
+
+        // Salary only makes sense for income.
+        if ($bucket === 'salary' && $type !== 'income') {
+            return null;
+        }
+
+        $candidates = $map[$bucket] ?? [];
+        foreach ($candidates as $want) {
+            foreach ($allowedNames as $n) {
+                if (strcasecmp($n, $want) === 0) {
+                    return ['category' => $n, 'confidence' => 0.6, 'source' => 'rules'];
+                }
+            }
+        }
+
+        return ['category' => $defaultCat, 'confidence' => 0.3, 'source' => 'fallback'];
+    }
+}
+

--- a/application/libraries/TransactionExtractor.php
+++ b/application/libraries/TransactionExtractor.php
@@ -47,7 +47,8 @@ class TransactionExtractor
                 'type' => $type,
                 'amount' => $amount,
                 'transaction_date' => $date,
-                'category' => 'Uncategorized',
+                // Category will be filled by server-side category classifier (AI-first).
+                'category' => '',
                 'title' => $title ?: $text,
                 'payee' => '',
             ],


### PR DESCRIPTION
Fixes #26.\n\n- Tambah CategoryClassifier (AI-first, kategori wajib dari allowed list)\n- Fallback keyword rules + default kategori\n- Chat::send mengisi draft.category otomatis (tidak lagi Uncategorized)\n- Prompt extractor LLM diperketat: category harus dari allowed categories