### PR TITLE
Fix AI Chat clarification loop

### DIFF
--- a/application/controllers/Chat.php
+++ b/application/controllers/Chat.php
@@ -113,9 +113,18 @@ class Chat extends CI_Controller
             return;
         }
 
+        // If the last assistant response asked for clarification, merge user reply with prior context
+        // so the extractor can fill the missing fields and avoid loops.
+        $pendingKey = 'chat_pending_' . (int)$user_id;
+        $pending = $this->session->userdata($pendingKey);
+        $messageForExtraction = $message;
+        if (is_array($pending) && !empty($pending['text']) && is_string($pending['text'])) {
+            $messageForExtraction = trim($pending['text'] . ' ' . $message);
+        }
+
         // Cheap dedup: if the same message is sent repeatedly, reuse last AI result for this user.
         $dedupKey = 'ai_dedup_' . (int)$user_id;
-        $msgHash = hash('sha256', $message);
+        $msgHash = hash('sha256', $messageForExtraction);
         $cached = $this->session->userdata($dedupKey);
 
         $this->Chat_model->add_message($thread_id, 'user', $message);
@@ -124,14 +133,14 @@ class Chat extends CI_Controller
         if (is_array($cached) && ($cached['hash'] ?? '') === $msgHash && !empty($cached['result'])) {
             $result = $cached['result'];
         } else {
-            $result = $this->transactionextractor->extract($message, $today);
+            $result = $this->transactionextractor->extract($messageForExtraction, $today);
         }
 
         // Optional LLM fallback: only when enabled and regex parser is uncertain.
         $aiCfg = $this->config->item('ai');
         if (!empty($aiCfg['ai_enabled']) && ($result['intent'] === 'clarify' || ($result['confidence'] ?? 0) < 0.7)) {
             if ($this->rate_limit_ok($aiCfg, (int)$user_id)) {
-                $llm = $this->extract_with_llm($message, $today, $aiCfg, (int)$user_id);
+                $llm = $this->extract_with_llm($messageForExtraction, $today, $aiCfg, (int)$user_id);
                 if ($llm) {
                     $result = $llm;
                 }
@@ -149,10 +158,18 @@ class Chat extends CI_Controller
                 $isAllowed = $existingCat !== '' && in_array($existingCat, $allowedNames, true);
 
                 if (!$isAllowed) {
-                    $cls = $this->categoryclassifier->classify($message, $type, $allowed ?: [], is_array($aiCfg) ? $aiCfg : []);
+                    $cls = $this->categoryclassifier->classify($messageForExtraction, $type, $allowed ?: [], is_array($aiCfg) ? $aiCfg : []);
                     $result['draft']['category'] = $cls['category'];
                 }
             }
+        }
+
+        // Update/clear pending context so clarification follows a straight path.
+        if (($result['intent'] ?? '') === 'clarify') {
+            // Avoid unbounded growth.
+            $this->session->set_userdata($pendingKey, ['text' => mb_substr($messageForExtraction, 0, 500, 'UTF-8')]);
+        } else {
+            $this->session->unset_userdata($pendingKey);
         }
 
         // Update dedup cache (no secrets).

--- a/application/libraries/TransactionExtractor.php
+++ b/application/libraries/TransactionExtractor.php
@@ -22,47 +22,48 @@ class TransactionExtractor
         $amount = $this->parse_amount_idr($lower);
         $date = $this->parse_date($lower, $todayYmd);
 
+        // Always build a partial draft so we can merge/continue on clarification loops.
+        $title = $this->guess_title($lower);
+        $draft = [
+            'type' => $type ?: '',
+            'amount' => ($amount === null) ? '' : $amount,
+            'transaction_date' => $date ?: '',
+            'category' => '', // Filled by server-side category classifier (AI-first).
+            'title' => $title ?: $text,
+            'payee' => '',
+        ];
+
         $missing = [];
         if (!$type) $missing[] = 'type';
         if ($amount === null) $missing[] = 'amount';
         if (!$date) $missing[] = 'transaction_date';
+        if (trim((string)($draft['title'] ?? '')) === '') $missing[] = 'title';
 
         if (!empty($missing)) {
             // Ask 1 most important question to proceed.
             if (in_array('amount', $missing, true)) {
-                return $this->clarify($missing, 'Berapa jumlahnya (contoh: 25k, 35 ribu, 2jt)?');
+                return $this->clarify($missing, 'Berapa jumlahnya (contoh: 25k, 35 ribu, 2jt)?', $draft);
             }
             if (in_array('type', $missing, true)) {
-                return $this->clarify($missing, 'Ini pemasukan atau pengeluaran?');
+                return $this->clarify($missing, 'Ini pemasukan atau pengeluaran?', $draft);
             }
-            return $this->clarify($missing, 'Tanggal berapa transaksinya? (contoh: hari ini / kemarin / 2026-04-27)');
+            return $this->clarify($missing, 'Tanggal berapa transaksinya? (contoh: hari ini / kemarin / 2026-04-27)', $draft);
         }
-
-        // Title heuristic: remove amount and some keywords; keep it short.
-        $title = $this->guess_title($lower);
 
         return [
             'intent' => 'create_transaction',
-            'draft' => [
-                'type' => $type,
-                'amount' => $amount,
-                'transaction_date' => $date,
-                // Category will be filled by server-side category classifier (AI-first).
-                'category' => '',
-                'title' => $title ?: $text,
-                'payee' => '',
-            ],
+            'draft' => $draft,
             'missing' => [],
             'questions' => [],
             'confidence' => 0.65,
         ];
     }
 
-    private function clarify($missing, $question)
+    private function clarify($missing, $question, $draft = null)
     {
         return [
             'intent' => 'clarify',
-            'draft' => null,
+            'draft' => is_array($draft) ? $draft : null,
             'missing' => array_values($missing),
             'questions' => [$question],
             'confidence' => 0.0,


### PR DESCRIPTION
Fixes #28.\n\n- Keep partial draft even on clarify\n- Store pending context per user and merge next reply into extraction input\n- Prevent repeated questions for fields already provided