### PR TITLE
Fix: .env terbaca tapi getenv() kosong (AI selalu false)

### DIFF
--- a/application/config/ai.php
+++ b/application/config/ai.php
@@ -7,26 +7,34 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 | Keep keys out of git. Prefer injecting via server env vars and reading with getenv().
 */
 
+// Prefer .env-loaded values from $_ENV/$_SERVER; fallback to getenv().
+function ai_env($key, $default = null) {
+    if (isset($_ENV[$key])) return $_ENV[$key];
+    if (isset($_SERVER[$key])) return $_SERVER[$key];
+    $v = getenv($key);
+    return ($v === false) ? $default : $v;
+}
+
 // Robust boolean parsing: supports true/false/1/0/yes/no/on/off.
-$aiEnabledRaw = getenv('AI_ENABLED');
+$aiEnabledRaw = ai_env('AI_ENABLED');
 $aiEnabledParsed = filter_var($aiEnabledRaw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
 $config['ai_enabled'] = ($aiEnabledParsed === null) ? false : (bool)$aiEnabledParsed;
 
 // Providers: gemini | groq
-$config['ai_provider_primary'] = getenv('AI_PROVIDER_PRIMARY') ?: 'gemini';
-$config['ai_provider_fallback'] = getenv('AI_PROVIDER_FALLBACK') ?: 'groq';
+$config['ai_provider_primary'] = ai_env('AI_PROVIDER_PRIMARY', 'gemini') ?: 'gemini';
+$config['ai_provider_fallback'] = ai_env('AI_PROVIDER_FALLBACK', 'groq') ?: 'groq';
 
 // Models (defaults chosen for cost/latency; adjust in env)
-$config['ai_model_primary'] = getenv('AI_MODEL_PRIMARY') ?: 'gemini-1.5-flash';
-$config['ai_model_fallback'] = getenv('AI_MODEL_FALLBACK') ?: 'llama-3.1-8b-instant';
+$config['ai_model_primary'] = ai_env('AI_MODEL_PRIMARY', 'gemini-1.5-flash') ?: 'gemini-1.5-flash';
+$config['ai_model_fallback'] = ai_env('AI_MODEL_FALLBACK', 'llama-3.1-8b-instant') ?: 'llama-3.1-8b-instant';
 
-$config['ai_timeout_seconds'] = (int)(getenv('AI_TIMEOUT_SECONDS') ?: 20);
-$config['ai_max_response_bytes'] = (int)(getenv('AI_MAX_RESPONSE_BYTES') ?: 50000);
+$config['ai_timeout_seconds'] = (int)(ai_env('AI_TIMEOUT_SECONDS', 20) ?: 20);
+$config['ai_max_response_bytes'] = (int)(ai_env('AI_MAX_RESPONSE_BYTES', 50000) ?: 50000);
 
 // Rate limiting (simple server-side protection)
-$config['ai_rate_limit_per_minute'] = (int)(getenv('AI_RATE_LIMIT_PER_MINUTE') ?: 15);
+$config['ai_rate_limit_per_minute'] = (int)(ai_env('AI_RATE_LIMIT_PER_MINUTE', 15) ?: 15);
 
 // API keys read from env
-$config['gemini_api_key'] = getenv('GEMINI_API_KEY') ?: '';
-$config['groq_api_key'] = getenv('GROQ_API_KEY') ?: '';
+$config['gemini_api_key'] = (string)(ai_env('GEMINI_API_KEY', '') ?: '');
+$config['groq_api_key'] = (string)(ai_env('GROQ_API_KEY', '') ?: '');
 

--- a/application/controllers/Chat.php
+++ b/application/controllers/Chat.php
@@ -260,10 +260,10 @@ class Chat extends CI_Controller
             // Diagnostics (do not leak secrets)
             'dotenv_loaded' => defined('DOTENV_LOADED') ? (bool)DOTENV_LOADED : false,
             'env_seen' => [
-                'AI_ENABLED_set' => getenv('AI_ENABLED') !== false,
-                'AI_ENABLED_value' => (getenv('AI_ENABLED') !== false) ? (string)getenv('AI_ENABLED') : null,
-                'GEMINI_API_KEY_present' => (string)getenv('GEMINI_API_KEY') !== '',
-                'GROQ_API_KEY_present' => (string)getenv('GROQ_API_KEY') !== '',
+                'AI_ENABLED_set' => isset($_ENV['AI_ENABLED']) || isset($_SERVER['AI_ENABLED']) || getenv('AI_ENABLED') !== false,
+                'AI_ENABLED_value' => isset($_ENV['AI_ENABLED']) ? (string)$_ENV['AI_ENABLED'] : (isset($_SERVER['AI_ENABLED']) ? (string)$_SERVER['AI_ENABLED'] : ((getenv('AI_ENABLED') !== false) ? (string)getenv('AI_ENABLED') : null)),
+                'GEMINI_API_KEY_present' => (string)(isset($_ENV['GEMINI_API_KEY']) ? $_ENV['GEMINI_API_KEY'] : (isset($_SERVER['GEMINI_API_KEY']) ? $_SERVER['GEMINI_API_KEY'] : (getenv('GEMINI_API_KEY') !== false ? getenv('GEMINI_API_KEY') : ''))) !== '',
+                'GROQ_API_KEY_present' => (string)(isset($_ENV['GROQ_API_KEY']) ? $_ENV['GROQ_API_KEY'] : (isset($_SERVER['GROQ_API_KEY']) ? $_SERVER['GROQ_API_KEY'] : (getenv('GROQ_API_KEY') !== false ? getenv('GROQ_API_KEY') : ''))) !== '',
             ],
             'ai_enabled' => (bool)($aiCfg['ai_enabled'] ?? false),
             'primary_provider' => (string)($aiCfg['ai_provider_primary'] ?? ''),


### PR DESCRIPTION
Fixes #22.\n\n- application/config/ai.php sekarang baca env dari / dulu, baru fallback ke getenv()\n- /chat/ai_status env_seen juga cek /\n\nHasil: kalau dotenv_loaded=true dan .env terisi, AI_ENABLED + API keys harus kebaca.