### PR TITLE
fix: harden session and cookie config (Closes #32)

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -337,7 +337,7 @@ $config['cache_query_string'] = FALSE;
 | https://codeigniter.com/userguide3/libraries/encryption.html
 |
 */
-$config['encryption_key'] = '';
+$config['encryption_key'] = getenv('ENCRYPTION_KEY') ?: '';
 
 /*
 |--------------------------------------------------------------------------
@@ -398,7 +398,7 @@ $config['sess_driver'] = 'files';
 $config['sess_cookie_name'] = 'ci_session';
 $config['sess_samesite'] = 'Lax';
 $config['sess_expiration'] = 7200;
-$config['sess_save_path'] = NULL;
+$config['sess_save_path'] = dirname(APPPATH) . '/session_data';
 $config['sess_match_ip'] = FALSE;
 $config['sess_time_to_update'] = 300;
 $config['sess_regenerate_destroy'] = FALSE;
@@ -422,8 +422,8 @@ $config['sess_regenerate_destroy'] = FALSE;
 $config['cookie_prefix'] = '';
 $config['cookie_domain'] = '';
 $config['cookie_path'] = '/';
-$config['cookie_secure'] = FALSE;
-$config['cookie_httponly'] = FALSE;
+$config['cookie_secure'] = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? TRUE : FALSE;
+$config['cookie_httponly'] = TRUE;
 $config['cookie_samesite'] = 'Lax';
 
 /*


### PR DESCRIPTION
- Load encryption_key from .env (ENCRYPTION_KEY)\n- Set cookie_httponly=TRUE\n- Set cookie_secure=TRUE if HTTPS\n- Set sess_save_path to non-public session_data folder\n\nCloses #32