### PR TITLE
fix: enable CSRF protection and require POST for delete endpoints (closes #33)

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -468,7 +468,7 @@ $config['global_xss_filtering'] = FALSE;
 | 'csrf_regenerate' = Regenerate token on every submission
 | 'csrf_exclude_uris' = Array of URIs which ignore CSRF checks
 */
-$config['csrf_protection'] = FALSE;
+$config['csrf_protection'] = TRUE;
 $config['csrf_token_name'] = 'csrf_test_name';
 $config['csrf_cookie_name'] = 'csrf_cookie_name';
 $config['csrf_expire'] = 7200;

--- a/application/controllers/Admin.php
+++ b/application/controllers/Admin.php
@@ -127,6 +127,11 @@ class Admin extends CI_Controller
 
     public function delete_category($id)
     {
+        if ($this->input->method() !== 'post') {
+            show_error('Direct access not allowed', 403);
+            return;
+        }
+
         $this->db->where('id', $id);
         $this->db->delete('categories');
         $this->session->set_flashdata('message', '<div class="alert alert-success border-brutal bg-pastel-red text-black" role="alert">Category deleted!</div>');

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -190,6 +190,11 @@ class Dashboard extends CI_Controller
 
     public function delete($id)
     {
+        if ($this->input->method() !== 'post') {
+            show_error('Direct access not allowed', 403);
+            return;
+        }
+
         $transaction = $this->Transaction_model->get_transaction($id);
         if ($transaction && $transaction['user_id'] == $this->session->userdata('user_id')) {
             $this->Transaction_model->delete_transaction($id);

--- a/application/views/admin/categories.php
+++ b/application/views/admin/categories.php
@@ -79,6 +79,7 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <form action="<?= base_url('admin/add_category') ?>" method="POST">
+                <?= csrf_field() ?>
                 <div class="modal-body p-4">
                     <div class="mb-3">
                         <label class="form-label fw-bold small">CATEGORY NAME</label>
@@ -111,6 +112,7 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <form id="editCategoryForm" action="" method="POST">
+                <?= csrf_field() ?>
                 <div class="modal-body p-4">
                     <div class="mb-3">
                         <label class="form-label fw-bold small">CATEGORY NAME</label>
@@ -143,15 +145,18 @@
                 <h5 class="modal-title font-mono fw-bold text-uppercase">Confirm Delete</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body p-4">
-                <p class="m-0">Are you sure you want to delete category "<span id="delete_cat_name_display"
-                        class="fw-bold"></span>"? This action cannot be undone.</p>
-            </div>
-            <div class="modal-footer border-top border-black">
-                <button type="button" class="btn btn-outline-dark border-brutal rounded-0 fw-bold"
-                    data-bs-dismiss="modal">CANCEL</button>
-                <a href="" id="confirmDeleteBtn" class="btn btn-danger border-brutal rounded-0 fw-bold">DELETE NOW</a>
-            </div>
+            <form id="deleteCategoryForm" action="" method="POST">
+                <?= csrf_field() ?>
+                <div class="modal-body p-4">
+                    <p class="m-0">Are you sure you want to delete category "<span id="delete_cat_name_display"
+                            class="fw-bold"></span>"? This action cannot be undone.</p>
+                </div>
+                <div class="modal-footer border-top border-black">
+                    <button type="button" class="btn btn-outline-dark border-brutal rounded-0 fw-bold"
+                        data-bs-dismiss="modal">CANCEL</button>
+                    <button type="submit" class="btn btn-danger border-brutal rounded-0 fw-bold">DELETE NOW</button>
+                </div>
+            </form>
         </div>
     </div>
 </div>
@@ -174,17 +179,7 @@
             const name = $(this).data('name');
 
             $('#delete_cat_name_display').text(name);
-            $('#confirmDeleteBtn').attr('href', '<?= base_url('admin/delete_category/') ?>' + id);
-        });
-
-        // Ensure clicking the confirmation link actually works with SWUP
-        $(document).on('click', '#confirmDeleteBtn', function (e) {
-            const href = $(this).attr('href');
-            if (href && href !== '') {
-                // If using SWUP, we might want to use its API, but window.location is safer for deletions
-                window.location.href = href;
-            }
-            e.preventDefault();
+            $('#deleteCategoryForm').attr('action', '<?= base_url('admin/delete_category/') ?>' + id);
         });
     });
 </script>

--- a/application/views/admin/login.php
+++ b/application/views/admin/login.php
@@ -7,6 +7,7 @@
             <p class="text-muted mb-4 text-center">Please enter your private admin key to proceed.</p>
 
             <form action="<?= base_url('admin/login') ?>" method="POST">
+                <?= csrf_field() ?>
                 <div class="mb-4">
                     <label class="form-label fw-bold">SECRET KEY</label>
                     <input type="password" name="secret_key" class="form-control border-brutal rounded-0 p-3"

--- a/application/views/auth/login.php
+++ b/application/views/auth/login.php
@@ -10,6 +10,7 @@
                 <?= $this->session->flashdata('message'); ?>
 
                 <form method="post" action="<?= base_url('auth/login'); ?>">
+                    <?= csrf_field() ?>
                     <div class="mb-3">
                         <label for="username" class="form-label font-mono fw-bold">USERNAME</label>
                         <input type="text" class="form-control form-control-brutal" id="username" name="username"

--- a/application/views/auth/register.php
+++ b/application/views/auth/register.php
@@ -8,6 +8,7 @@
                 </div>
 
                 <form method="post" action="<?= base_url('auth/register'); ?>">
+                    <?= csrf_field() ?>
                     <div class="mb-3">
                         <label for="name" class="form-label font-mono fw-bold">FULL NAME</label>
                         <input type="text" class="form-control form-control-brutal" id="name" name="name"

--- a/application/views/dashboard/detail.php
+++ b/application/views/dashboard/detail.php
@@ -38,9 +38,10 @@
         </div>
     </div>
 
-    <a href="<?= base_url('dashboard/delete/' . $transaction['id']) ?>"
-        class="btn btn-brutal w-100 py-3 fw-bold bg-pastel-red text-black"
-        onclick="return confirm('Are you sure you want to delete this transaction?')">
-        DELETE TRANSACTION
-    </a>
+    <form action="<?= base_url('dashboard/delete/' . $transaction['id']) ?>" method="POST" onsubmit="return confirm('Are you sure you want to delete this transaction?');">
+        <?= csrf_field() ?>
+        <button type="submit" class="btn btn-brutal w-100 py-3 fw-bold bg-pastel-red text-black">
+            DELETE TRANSACTION
+        </button>
+    </form>
 </div>


### PR DESCRIPTION
## Summary
- Enable CSRF protection in config.php (`csrf_protection = TRUE`)
- Add POST requirement check to `Dashboard::delete` and `Admin::delete_category` endpoints
- Convert delete link (GET) to POST form with CSRF token in views
- Add `csrf_field()` to all existing forms (login, register, admin category forms)

## Security Impact
- Requests without CSRF token now fail with 403 error
- Delete actions no longer work via GET requests (prevents CSRF attacks)

Closes #33