### PR TITLE
fix: escape user-generated output to prevent stored XSS (closes #34)

### DIFF
--- a/application/views/admin/categories.php
+++ b/application/views/admin/categories.php
@@ -29,7 +29,7 @@
                 foreach ($categories as $cat): ?>
                     <tr class="align-middle">
                         <td class="p-3 fw-bold"><?= $no ?></td>
-                        <td class="p-3"><?= $cat['name'] ?></td>
+                        <td class="p-3"><?= htmlspecialchars($cat['name'], ENT_QUOTES, 'UTF-8') ?></td>
                         <td class="p-3">
                             <?php if ($cat['type'] == 'income'): ?>
                                 <span

--- a/application/views/admin/users.php
+++ b/application/views/admin/users.php
@@ -22,9 +22,9 @@
                 foreach ($users as $user): ?>
                     <tr class="align-middle">
                         <td class="p-3 fw-bold"><?= $no ?></td>
-                        <td class="p-3"><?= $user['name'] ?></td>
+                        <td class="p-3"><?= htmlspecialchars($user['name'], ENT_QUOTES, 'UTF-8') ?></td>
                         <td class="p-3"><span
-                                class="badge bg-pastel-blue text-black border border-black rounded-0"><?= $user['username'] ?></span>
+                                class="badge bg-pastel-blue text-black border border-black rounded-0"><?= htmlspecialchars($user['username'], ENT_QUOTES, 'UTF-8') ?></span>
                         </td>
                         <td class="p-3">
                             <?php if ($user['role'] == 'admin'): ?>

--- a/application/views/dashboard/detail.php
+++ b/application/views/dashboard/detail.php
@@ -25,11 +25,11 @@
         <div class="border-top border-2 border-black pt-4">
             <div class="mb-3">
                 <small class="font-mono text-muted fw-bold">TITLE</small>
-                <h5 class="fw-bold mt-1"><?= $transaction['title'] ?></h5>
+                <h5 class="fw-bold mt-1"><?= htmlspecialchars($transaction['title'], ENT_QUOTES, 'UTF-8') ?></h5>
             </div>
             <div class="mb-3">
                 <small class="font-mono text-muted fw-bold">CATEGORY</small>
-                <h5 class="fw-bold mt-1"><?= $transaction['category'] ?></h5>
+                <h5 class="fw-bold mt-1"><?= htmlspecialchars($transaction['category'], ENT_QUOTES, 'UTF-8') ?></h5>
             </div>
             <div class="mb-3">
                 <small class="font-mono text-muted fw-bold">DATE</small>

--- a/application/views/dashboard/profile.php
+++ b/application/views/dashboard/profile.php
@@ -15,8 +15,8 @@
             style="width: 80px; height: 80px;">
             <span class="iconify" data-icon="lucide:user" data-width="40"></span>
         </div>
-        <h4 class="fw-bold mb-1"><?= $user['name'] ?></h4>
-        <p class="font-mono text-muted mb-0">@<?= $user['username'] ?></p>
+        <h4 class="fw-bold mb-1"><?= htmlspecialchars($user['name'], ENT_QUOTES, 'UTF-8') ?></h4>
+        <p class="font-mono text-muted mb-0">@<?= htmlspecialchars($user['username'], ENT_QUOTES, 'UTF-8') ?></p>
     </div>
 
     <!-- Edit Profile Form -->

--- a/application/views/templates/admin_header.php
+++ b/application/views/templates/admin_header.php
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?= isset($title) ? $title . ' | ' : '' ?> Admin Panel</title>
+    <title><?= isset($title) ? htmlspecialchars($title, ENT_QUOTES, 'UTF-8') . ' | ' : '' ?> Admin Panel</title>
     <!-- Bootstrap 5 CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Custom CSS -->
@@ -210,7 +210,7 @@
                                 style="font-size: 0.65rem; line-height: 1;">ADMIN SESSION</small>
                             <span class="d-block fw-bold text-uppercase text-truncate font-mono"
                                 style="font-size: 0.85rem;">
-                                <?= $this->session->userdata('username'); ?>
+                                <?= htmlspecialchars($this->session->userdata('username'), ENT_QUOTES, 'UTF-8'); ?>
                             </span>
                         </div>
                     </div>

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -32,7 +32,7 @@
                         </a>
                     <?php endif; ?>
                     <span class="badge bg-pastel-yellow text-black border border-black rounded-0 fw-bold">
-                        <?= $this->session->userdata('name'); ?>
+                        <?= htmlspecialchars($this->session->userdata('name'), ENT_QUOTES, 'UTF-8'); ?>
                     </span>
                     <a href="<?= base_url('auth/logout') ?>" class="btn btn-sm border-0">
                         <span class="iconify" data-icon="lucide:log-out" style="width: 20px; height: 20px;"></span>


### PR DESCRIPTION
## Summary
- Use `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` for all user-controlled output:
  - Transaction title/category in detail.php
  - User name/username in profile.php and header.php
  - Admin username in admin_header.php
  - Admin user name/username in admin/users.php
  - Category name in admin/categories.php
  - Page title in admin_header.php

## Security Impact
- Malicious input like `<img src=x onerror=alert(1)>` will be escaped and not execute
- Stored XSS via DB-persisted data is now mitigated

Closes #34