### PR TITLE
fix: use safe json_encode flags to prevent XSS in scripts (closes #35)

### DIFF
--- a/application/views/dashboard/add.php
+++ b/application/views/dashboard/add.php
@@ -131,7 +131,7 @@
         });
 
         // Category Filtering Logic
-        const allCategories = <?= json_encode($categories) ?>;
+        const allCategories = <?= json_encode($categories, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
         const $typeRadios = $('input[name="type"]');
         const $categorySelect = $('#categorySelect');
         const $categoryWrapper = $('#category-select-wrapper');

--- a/application/views/dashboard/stats.php
+++ b/application/views/dashboard/stats.php
@@ -291,8 +291,8 @@ if (!empty($category_income)) {
                 if (<?= !empty($exp_totals) ? 'true' : 'false' ?>) {
                     createDonutChart(
                         'expenseChart',
-                        <?= json_encode($exp_labels) ?>,
-                        <?= json_encode($exp_totals) ?>,
+                        <?= json_encode($exp_labels, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>,
+                        <?= json_encode($exp_totals, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>,
                         'expenseLoading'
                     );
                 } else {
@@ -304,8 +304,8 @@ if (!empty($category_income)) {
                 if (<?= !empty($inc_totals) ? 'true' : 'false' ?>) {
                     createDonutChart(
                         'incomeChart',
-                        <?= json_encode($inc_labels) ?>,
-                        <?= json_encode($inc_totals) ?>,
+                        <?= json_encode($inc_labels, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>,
+                        <?= json_encode($inc_totals, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>,
                         'incomeLoading'
                     );
                 } else {
@@ -316,9 +316,9 @@ if (!empty($category_income)) {
 
                 /* ================= TREND CHART ================= */
                 <?php if (!empty($monthly_summary) && count($monthly_summary) > 1): ?>
-                    const trendLabels = <?= json_encode(array_column($monthly_summary, 'month_year')) ?>;
-                    const trendIncome = <?= json_encode(array_column($monthly_summary, 'total_income')) ?>;
-                    const trendExpense = <?= json_encode(array_column($monthly_summary, 'total_expense')) ?>;
+                    const trendLabels = <?= json_encode(array_column($monthly_summary, 'month_year'), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+                    const trendIncome = <?= json_encode(array_column($monthly_summary, 'total_income'), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+                    const trendExpense = <?= json_encode(array_column($monthly_summary, 'total_expense'), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
 
                     const trendCanvas = document.getElementById('trendChart');
                     if (trendCanvas) {


### PR DESCRIPTION
## Summary
- Add `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT` flags to all `json_encode()` calls:
  - `dashboard/add.php` - allCategories
  - `dashboard/stats.php` - expense/income charts, trend charts

## Security Impact
- Category names containing `</script>` no longer break out of script tags
- Names with `<>` render safely

Closes #35