### PR TITLE
fix: harden base_url to prevent host header injection (closes #38)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ GROQ_API_KEY=
 # Set a strong secret key for admin panel access
 # ADMIN_SECRET_KEY=
 
+# Application (REQUIRED for production)
+# Set the full base URL for the application (include trailing slash)
+# BASE_URL=https://example.com/
+

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -23,15 +23,22 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 | a PHP script and you can easily do that on your own.
 |
 */
-$protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off'
-    || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
+$config['base_url'] = getenv('BASE_URL') ?: '';
 
-$host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+if (empty($config['base_url'])) {
+    $allowed_hosts = ['localhost', '127.0.0.1'];
+    $host = $_SERVER['HTTP_HOST'] ?? '';
 
-$script = $_SERVER['SCRIPT_NAME'] ?? '';
-$path = str_replace(basename($script), '', $script);
-
-$config['base_url'] = $protocol . $host . $path;
+    if ($host && in_array($host, $allowed_hosts, true)) {
+        $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off'
+            || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
+        $script = $_SERVER['SCRIPT_NAME'] ?? '';
+        $path = str_replace(basename($script), '', $script);
+        $config['base_url'] = $protocol . $host . $path;
+    } else {
+        $config['base_url'] = 'https://localhost/';
+    }
+}
 // $config['base_url'] = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? "https" : "http");
 // $config['base_url'] .= "://".$_SERVER['HTTP_HOST']."/finance_app/";
 


### PR DESCRIPTION
## Summary
- Use `BASE_URL` environment variable if set
- Only allow `localhost` and `127.0.0.1` in development mode
- Default to `https://localhost/` if no valid config

## Security Impact
- Prevents host header injection attacks
- Malicious Host headers cannot change the app base URL

## Setup Required
In production, set in `.env`:
```
BASE_URL=https://yourdomain.com/
```

Closes #38