### PR TITLE
fix: enforce password policy and add login brute-force protection (closes #41)

### DIFF
--- a/application/controllers/Auth.php
+++ b/application/controllers/Auth.php
@@ -25,6 +25,23 @@ class Auth extends CI_Controller
             redirect('dashboard');
         }
 
+        $max_attempts = 5;
+        $lockout_seconds = 300;
+        $session_key = 'login_attempts';
+        $lockout_key = 'login_locked_until';
+
+        $failed_attempts = $this->session->userdata($session_key) ?: 0;
+        $locked_until = $this->session->userdata($lockout_key) ?: 0;
+
+        if ($locked_until > time()) {
+            $remaining = $locked_until - time();
+            $this->session->set_flashdata('message', '<div class="alert alert-danger border-brutal" role="alert">Too many login attempts. Try again in ' . ceil($remaining / 60) . ' minute(s).</div>');
+            $this->load->view('templates/auth_header');
+            $this->load->view('auth/login');
+            $this->load->view('templates/footer');
+            return;
+        }
+
         $this->form_validation->set_rules('username', 'Username', 'required|trim');
         $this->form_validation->set_rules('password', 'Password', 'required|trim');
 
@@ -40,6 +57,8 @@ class Auth extends CI_Controller
 
             if ($user) {
                 if (password_verify($password, $user['password'])) {
+                    $this->session->unset_userdata($session_key);
+                    $this->session->unset_userdata($lockout_key);
                     $this->session->sess_regenerate(true);
                     $this->session->set_userdata([
                         'user_id' => $user['id'],
@@ -49,11 +68,28 @@ class Auth extends CI_Controller
                     ]);
                     redirect('dashboard');
                 } else {
-                    $this->session->set_flashdata('message', '<div class="alert alert-danger border-brutal" role="alert">Wrong password!</div>');
+                    $failed_attempts++;
+                    $this->session->set_userdata($session_key, $failed_attempts);
+
+                    if ($failed_attempts >= $max_attempts) {
+                        $this->session->set_userdata($lockout_key, time() + $lockout_seconds);
+                        $this->session->set_flashdata('message', '<div class="alert alert-danger border-brutal" role="alert">Too many failed attempts. Locked for 5 minutes.</div>');
+                    } else {
+                        $remaining = $max_attempts - $failed_attempts;
+                        $this->session->set_flashdata('message', '<div class="alert alert-danger border-brutal" role="alert">Wrong password! ' . $remaining . ' attempt(s) remaining.</div>');
+                    }
                     redirect('auth/login');
                 }
             } else {
-                $this->session->set_flashdata('message', '<div class="alert alert-danger border-brutal" role="alert">User not found!</div>');
+                $failed_attempts++;
+                $this->session->set_userdata($session_key, $failed_attempts);
+
+                if ($failed_attempts >= $max_attempts) {
+                    $this->session->set_userdata($lockout_key, time() + $lockout_seconds);
+                    $this->session->set_flashdata('message', '<div class="alert alert-danger border-brutal" role="alert">Too many failed attempts. Locked for 5 minutes.</div>');
+                } else {
+                    $this->session->set_flashdata('message', '<div class="alert alert-danger border-brutal" role="alert">User not found!</div>');
+                }
                 redirect('auth/login');
             }
         }
@@ -67,17 +103,25 @@ class Auth extends CI_Controller
 
         $this->form_validation->set_rules('name', 'Name', 'required|trim');
         $this->form_validation->set_rules('username', 'Username', 'required|trim|is_unique[users.username]');
-        $this->form_validation->set_rules('password', 'Password', 'required|min_length[3]');
+        $this->form_validation->set_rules('password', 'Password', 'required|min_length[8]|max_length[72]');
 
         if ($this->form_validation->run() == FALSE) {
             $this->load->view('templates/auth_header');
             $this->load->view('auth/register');
             $this->load->view('templates/footer');
         } else {
+            $password = $this->input->post('password');
+
+            if (strlen($password) < 8) {
+                $this->session->set_flashdata('message', '<div class="alert alert-danger border-brutal" role="alert">Password must be at least 8 characters.</div>');
+                redirect('auth/register');
+                return;
+            }
+
             $data = [
                 'name' => htmlspecialchars($this->input->post('name', true)),
                 'username' => htmlspecialchars($this->input->post('username', true)),
-                'password' => password_hash($this->input->post('password'), PASSWORD_DEFAULT)
+                'password' => password_hash($password, PASSWORD_DEFAULT)
             ];
 
             $this->User_model->register($data);


### PR DESCRIPTION
## Summary
- Raise minimum password length from 3 to 8 characters
- Add max_length validation (72 for bcrypt compatibility)
- Add login brute-force protection:
  - Max 5 failed attempts triggers 5-minute lockout
  - Track attempts in session
  - Show remaining attempts to user

## Security Impact
- Short/weak passwords are rejected
- Brute-force login attempts are rate limited

Closes #41