### PR TITLE
fix: sync database schema with code for user role and goal_amount

### DIFF
--- a/application/controllers/Auth.php
+++ b/application/controllers/Auth.php
@@ -121,7 +121,8 @@ class Auth extends CI_Controller
             $data = [
                 'name' => htmlspecialchars($this->input->post('name', true)),
                 'username' => htmlspecialchars($this->input->post('username', true)),
-                'password' => password_hash($password, PASSWORD_DEFAULT)
+                'password' => password_hash($password, PASSWORD_DEFAULT),
+                'role' => 'user'
             ];
 
             $this->User_model->register($data);

--- a/finance_app.sql
+++ b/finance_app.sql
@@ -3,6 +3,8 @@ CREATE TABLE `users` (
   `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `username` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `password` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `role` enum('user','admin') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'user',
+  `goal_amount` decimal(15,2) NOT NULL DEFAULT 0,
   `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`)

--- a/sql/migrations/001_add_role_and_goal_amount.sql
+++ b/sql/migrations/001_add_role_and_goal_amount.sql
@@ -1,0 +1,7 @@
+-- Migration: Add role and goal_amount columns to users table
+-- Date: 2026-04-29
+-- Issue: #42 - Sync database schema with code for user role and goal_amount
+
+ALTER TABLE `users`
+  ADD COLUMN `role` enum('user','admin') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'user' AFTER `password`,
+  ADD COLUMN `goal_amount` decimal(15,2) NOT NULL DEFAULT 0 AFTER `role`;


### PR DESCRIPTION
## Summary
- Add `role` and `goal_amount` columns to `users` table in `finance_app.sql`
- Create migration file for existing databases (`sql/migrations/001_add_role_and_goal_amount.sql`)
- Update register method to include default role 'user'

## Changes
- Updated `finance_app.sql` to include `role` enum column (defaults to 'user') and `goal_amount` decimal column (defaults to 0)
- Created migration SQL file for existing installations
- Added default 'user' role in Auth.php register method

## Acceptance
- Fresh install works without errors for login/register/dashboard
- Existing databases can be migrated using the provided SQL migration file

Fixes #42